### PR TITLE
【サーバーサイド】商品情報編集

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -36,7 +36,7 @@
       var parentCategory = document.getElementById('parent_category').value; //選択された親カテゴリーの名前を取得
       if (parentCategory != "---"){ //親カテゴリーが初期値でないことを確認
         $.ajax({
-          url: 'get_category_children',
+          url: '/items/get_category_children',
           type: 'GET',
           data: { parent_name: parentCategory },
           dataType: 'json'
@@ -67,7 +67,7 @@
       var childId = $('#child_category option:selected').data('category'); //選択された子カテゴリーのidを取得
       if (childId != "---"){ //子カテゴリーが初期値でないことを確認
         $.ajax({
-          url: 'get_category_grandchildren',
+          url: '/items/get_category_grandchildren',
           type: 'GET',
           data: { child_id: childId },
           dataType: 'json'

--- a/app/assets/javascripts/imgadd.js
+++ b/app/assets/javascripts/imgadd.js
@@ -35,9 +35,7 @@
       const targetIndex = $(this).parent().data('index');
       // ファイルのブラウザ上でのURLを取得する
       const file = e.target.files[0];
-      console.log(file);
       const blobUrl = window.URL.createObjectURL(file);
-      console.log(blobUrl);
       
       // 該当indexを持つimgタグがあれば取得して変数imgに入れる(画像変更の処理)
       if (img = $(`img[data-index="${targetIndex}"]`)[0]) {

--- a/app/assets/javascripts/imgadd.js
+++ b/app/assets/javascripts/imgadd.js
@@ -35,7 +35,9 @@
       const targetIndex = $(this).parent().data('index');
       // ファイルのブラウザ上でのURLを取得する
       const file = e.target.files[0];
+      console.log(file);
       const blobUrl = window.URL.createObjectURL(file);
+      console.log(blobUrl);
       
       // 該当indexを持つimgタグがあれば取得して変数imgに入れる(画像変更の処理)
       if (img = $(`img[data-index="${targetIndex}"]`)[0]) {

--- a/app/assets/javascripts/tops.js
+++ b/app/assets/javascripts/tops.js
@@ -1,4 +1,5 @@
 $(function() {
+  $(document).on('turbolinks:load', function() {
   // カテゴリ色変更
   $("#categoryBtn").on("mouseover", function() {
     $(this).css({
@@ -38,5 +39,5 @@ $(function() {
     }, function(){
     $(">ul",this).slideUp();
   });
-  
+});
 });

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -84,7 +84,7 @@ main.showItem {
       .mainBox__destroyBtn,
       .mainBox__buyBtn{
         background-color: var(--main-color);
-        margin: 7px 0;
+        margin: 30px 0;
         padding: 3px 0;
       }
       #overlay{
@@ -141,7 +141,7 @@ main.showItem {
       }
       .mainBox__soldBtn{
         background-color: hotpink;
-        margin: 7px 0;
+        margin: 30px 0;
         padding: 3px 0;
       }
       a{

--- a/app/assets/stylesheets/new.scss
+++ b/app/assets/stylesheets/new.scss
@@ -351,6 +351,10 @@ $mainBackgroundColor: rgb(245, 245, 245);
           text-decoration: underline;
           opacity: 0.5;
         }
+        .itemsEdit__alert{
+          color: red;
+          margin-top: 3px;
+        }
         
   // フッターSP
   &__footer {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -55,22 +55,19 @@ class ItemsController < ApplicationController
 
   def edit
     @parents = Category.all.order("id ASC").limit(13)
-
     #セレクトボックスの初期値設定
-    @category_parent_array = ["---"]
+    @category_parent_array = []
       # データベースから、親カテゴリーのみ抽出し、配列化
     Category.where(ancestry: nil).each do |parent|
         @category_parent_array << parent.name
     end
   end
-
   # 以下全て、formatはjsonのみ
   # 親カテゴリーが選択された後に動くアクション
   def get_category_children
     #選択された親カテゴリーに紐付く子カテゴリーの配列を取得
     @category_children = Category.find_by(name: "#{params[:parent_name]}", ancestry: nil).children
   end
-
   # 子カテゴリーが選択された後に動くアクション
   def get_category_grandchildren
     #選択された子カテゴリーに紐付く孫カテゴリーの配列を取得
@@ -79,18 +76,25 @@ class ItemsController < ApplicationController
 
   def update
     if @item.update(item_params)
-      redirect_to root_path
+      redirect_to item_path
     else
+      @parents = Category.all.order("id ASC").limit(13)
+      #セレクトボックスの初期値設定
+      @category_parent_array = []
+        # データベースから、親カテゴリーのみ抽出し、配列化
+      Category.where(ancestry: nil).each do |parent|
+          @category_parent_array << parent.name
+      end
       render :edit
     end
   end
 
   def destroy
-    if current_user.id == @item.user_id
+    if current_user.id == @item.seller_id
       @item.destroy
       redirect_to root_path
     else
-      render :show,　notice: '削除できませんでした'
+      render :show, notice: '削除できませんでした'
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:index, :edit, :show, :confirm, :destroy]
+  before_action :set_item, only: [:index, :edit, :show, :confirm, :destroy, :update]
   before_action :set_category, only: [:index, :show, :destroy]
 
   def index
@@ -54,6 +54,27 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    @parents = Category.all.order("id ASC").limit(13)
+
+    #セレクトボックスの初期値設定
+    @category_parent_array = ["---"]
+      # データベースから、親カテゴリーのみ抽出し、配列化
+    Category.where(ancestry: nil).each do |parent|
+        @category_parent_array << parent.name
+    end
+  end
+
+  # 以下全て、formatはjsonのみ
+  # 親カテゴリーが選択された後に動くアクション
+  def get_category_children
+    #選択された親カテゴリーに紐付く子カテゴリーの配列を取得
+    @category_children = Category.find_by(name: "#{params[:parent_name]}", ancestry: nil).children
+  end
+
+  # 子カテゴリーが選択された後に動くアクション
+  def get_category_grandchildren
+    #選択された子カテゴリーに紐付く孫カテゴリーの配列を取得
+    @category_grandchildren = Category.find("#{params[:child_id]}").children
   end
 
   def update

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -93,7 +93,7 @@
               ブランド
             .itemsNew__tag--gray
               任意
-          %input{type: "text", placeholder: "選択してください" ,class: "itemsNew__inputBox"}
+          =f.text_field :brand, placeholder: "入力してください", class: "itemsNew__inputBox"
 
         .itemsNew__innerContainer
           .itemsNew__title
@@ -173,6 +173,8 @@
 
         .itemsNew__btnContainer
           .itemsNew__modalOpen
+            -# buyer_idに初期状態である0（未売却）を入れる
+            = f.hidden_field :buyer_id, value: "0"
             = f.submit "出品", class:"itemsNew__sellBtn"
             %button{type: "submit", class: "itemsNew__sellBtn itemsNew__backBtn"}
               もどる

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -25,8 +25,8 @@
             #image-box
               #previews
                 - if @item.persisted?
-                  = @item.images.each_with_index do |image, i|
-                    = image_tag image.src.url, data: { index: i }, width: "100", height: '100'
+                  - @item.images.each_with_index do |image, i|
+                    = image_tag image.url, data: { index: i }, width: "100", height: '100'
 
               = f.fields_for :images do |image|
                 .js-file_group{data:{index: image.index}}

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -85,7 +85,8 @@
           = f.select :size, Item.sizes.keys,{prompt: '選択してください'},class: "itemsNew__selectBox"
           .itemsNew__alert.displayNone
             選択してください
-          = render partial: 'error-messages', locals: { item: @item, column: "size"}
+          .itemsEdit__alert
+            = render partial: 'error-messages', locals: { item: @item, column: "size"}
         
         .itemsNew__innerContainer
           .itemsNew__title
@@ -173,8 +174,6 @@
 
         .itemsNew__btnContainer
           .itemsNew__modalOpen
-            -# buyer_idに初期状態である0（未売却）を入れる
-            = f.hidden_field :buyer_id, value: "0"
             = f.submit "出品", class:"itemsNew__sellBtn"
             %button{type: "submit", class: "itemsNew__sellBtn itemsNew__backBtn"}
               もどる

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -50,7 +50,8 @@
             .itemsNew__tag
               必須
           = f.text_field :name, placeholder: "40字まで", class: "itemsNew__inputBox"
-          = render partial: 'error-messages', locals: { item: @item, column: "name"}
+          .itemsEdit__alert
+            = render partial: 'error-messages', locals: { item: @item, column: "name"}
           
         .itemsNew__innerContainer
           .itemsNew__title
@@ -59,7 +60,8 @@
             .itemsNew__tag
               必須
           = f.text_area :explanation, class: "itemsNew__textareaBox", placeholder: "商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", rows: "7"
-          = render partial: 'error-messages', locals: { item: @item, column: "explanation"}
+          .itemsEdit__alert
+            = render partial: 'error-messages', locals: { item: @item, column: "explanation"}
 
       .itemsNew__container
         .itemsNew__mainTitle
@@ -74,7 +76,8 @@
             = f.select :category, @category_parent_array, {selected: @item.category.parent.parent.name,prompt: '選択してください'}, {class: 'listing-select-wrapper__box--select itemsNew__selectBox', id: 'parent_category'}
             .itemsNew__alert.displayNone
               選択してください
-            = render partial: 'error-messages', locals: { item: @item, column: "category_id"}
+            .itemsEdit__alert
+              = render partial: 'error-messages', locals: { item: @item, column: "category_id"}
         
         .itemsNew__innerContainer
           .itemsNew__title
@@ -85,7 +88,8 @@
           = f.select :size, Item.sizes.keys,{include_blank: "---",prompt: '選択してください'},class: "itemsNew__selectBox"
           .itemsNew__alert.displayNone
             選択してください
-          = render partial: 'error-messages', locals: { item: @item, column: "size"}
+          .itemsEdit__alert
+            = render partial: 'error-messages', locals: { item: @item, column: "size"}
         
         .itemsNew__innerContainer
           .itemsNew__title
@@ -104,7 +108,8 @@
           = f.select :condition, Item.conditions.keys,{include_blank: "---",prompt: '選択してください'},class: "itemsNew__selectBox"
           .itemsNew__alert.displayNone
             入力してください
-          = render partial: 'error-messages', locals: { item: @item, column: "condition"}
+          .itemsEdit__alert
+            = render partial: 'error-messages', locals: { item: @item, column: "condition"}
 
       .itemsNew__container
         .itemsNew__mainTitle
@@ -118,7 +123,8 @@
           = f.select :fee_which, Item.fee_whiches.keys,{include_blank: "---",prompt: '選択してください'}, class: "itemsNew__selectBox"
           .itemsNew__alert.displayNone
             選択してください
-          = render partial: 'error-messages', locals: { item: @item, column: "fee_which"}
+          .itemsEdit__alert
+            = render partial: 'error-messages', locals: { item: @item, column: "fee_which"}
 
         .itemsNew__innerContainer
           .itemsNew__title
@@ -129,7 +135,8 @@
           = f.select :from_where, Item.from_wheres.keys,{include_blank: "---",prompt: '選択してください'}, class: "itemsNew__selectBox"
           .itemsNew__alert.displayNone
             選択してください
-          = render partial: 'error-messages', locals: { item: @item, column: "from_where"}
+          .itemsEdit__alert
+            = render partial: 'error-messages', locals: { item: @item, column: "from_where"}
 
         .itemsNew__innerContainer
           .itemsNew__title
@@ -140,7 +147,8 @@
           = f.select :delivery_date, Item.delivery_dates.keys,{include_blank: "---",prompt: '選択してください'}, class: "itemsNew__selectBox"
           .itemsNew__alert.displayNone
             選択してください
-          = render partial: 'error-messages', locals: { item: @item, column: "delivery_date"}
+          .itemsEdit__alert
+            = render partial: 'error-messages', locals: { item: @item, column: "delivery_date"}
 
       .itemsNew__container
         .itemsNew__mainTitle
@@ -157,7 +165,8 @@
         .itemsNew__alertInputBox
           .itemsNew__alertInputBox2.displayNone
             300以上9999999以下で入力してください
-        = render partial: 'error-messages', locals: { item: @item, column: "price"}
+          .itemsEdit__alert
+            = render partial: 'error-messages', locals: { item: @item, column: "price"}
 
         .itemsNew__sellPrice
           .itemsNew__sellPrice--left
@@ -172,8 +181,6 @@
             ー
         .itemsNew__btnContainer
           .itemsNew__modalOpen
-            -# buyer_idに初期状態である0（未売却）を入れる
-            = f.hidden_field :buyer_id, value: "0"
             = f.submit "変更する", class:"itemsNew__sellBtn",data: { disable_with: "更新中..." }
             %button{type: "submit", class: "itemsNew__sellBtn itemsNew__backBtn"}
               もどる

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,1 +1,215 @@
-= render partial: 'form'
+.itemsNew
+
+  .itemsNew__header
+    = link_to root_path do
+      = image_tag 'logo.png', alt: 'FURIMA', class: 'itemsNew__logo'
+
+  .itemsNew__body
+    = form_for @item do |f|
+      .itemsNew__container
+        .itemsNew__title
+          .itemsNew__subTitle
+            出品画像
+          .itemsNew__tag
+            必須
+        .itemsNew__photoExplanation 
+          最大10枚までアップロードできます
+        .sell-form.dropzone#item-dropzone
+          %h2.sell-form__header
+            商品情報を入力
+          .sell-form-container
+            %label.sell-form-container__label
+              出品画像
+            %span.sell-form-container__require
+              必須
+            #image-box
+              #previews
+                - if @item.persisted?
+                  - @item.images.each_with_index do |image, i|
+                    = image_tag image.url, data: { index: i }, width: "100", height: '100'
+
+              = f.fields_for :images do |image|
+                .js-file_group{data:{index: image.index}}
+                  = image.file_field :url, class: "js-file img-add"
+
+                - if @item.persisted?
+                  = image.check_box :_destroy, data:{ index: image.index }, class: 'hidden-destroy'
+                  
+              - if @item.persisted?
+                .js-file_group{data:{index:"@item.images.count"}}
+                  = file_field_tag :url, name: "item[images_attributes][#{@item.images.count}][url]", class: 'js-file'
+                  .js-remove 削除
+          = render partial: 'error-messages', locals: { item: @item, column: "images"}
+              
+
+      .itemsNew__container
+        .itemsNew__innerContainer
+          .itemsNew__title
+            .itemsNew__subTitle
+              出品名
+            .itemsNew__tag
+              必須
+          = f.text_field :name, placeholder: "40字まで", class: "itemsNew__inputBox"
+          = render partial: 'error-messages', locals: { item: @item, column: "name"}
+          
+        .itemsNew__innerContainer
+          .itemsNew__title
+            .itemsNew__subTitle
+              出品の説明
+            .itemsNew__tag
+              必須
+          = f.text_area :explanation, class: "itemsNew__textareaBox", placeholder: "商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", rows: "7"
+          = render partial: 'error-messages', locals: { item: @item, column: "explanation"}
+
+      .itemsNew__container
+        .itemsNew__mainTitle
+          商品の詳細
+        .itemsNew__innerContainer
+          .listing-product-detail__category
+            .itemsNew__title
+              .itemsNew__subTitle
+                カテゴリー
+              .itemsNew__tag
+                必須
+            = f.select :category, @category_parent_array, {selected: @item.category.parent.parent.name,prompt: '選択してください'}, {class: 'listing-select-wrapper__box--select itemsNew__selectBox', id: 'parent_category'}
+            .itemsNew__alert.displayNone
+              選択してください
+            = render partial: 'error-messages', locals: { item: @item, column: "category_id"}
+        
+        .itemsNew__innerContainer
+          .itemsNew__title
+            .itemsNew__subTitle
+              サイズ
+            .itemsNew__tag
+              必須
+          = f.select :size, Item.sizes.keys,{include_blank: "---",prompt: '選択してください'},class: "itemsNew__selectBox"
+          .itemsNew__alert.displayNone
+            選択してください
+          = render partial: 'error-messages', locals: { item: @item, column: "size"}
+        
+        .itemsNew__innerContainer
+          .itemsNew__title
+            .itemsNew__subTitle
+              ブランド
+            .itemsNew__tag--gray
+              任意
+          =f.text_field :brand, placeholder: "入力してください", class: "itemsNew__inputBox"
+
+        .itemsNew__innerContainer
+          .itemsNew__title
+            .itemsNew__subTitle
+              商品の状態
+            .itemsNew__tag
+              必須
+          = f.select :condition, Item.conditions.keys,{include_blank: "---",prompt: '選択してください'},class: "itemsNew__selectBox"
+          .itemsNew__alert.displayNone
+            入力してください
+          = render partial: 'error-messages', locals: { item: @item, column: "condition"}
+
+      .itemsNew__container
+        .itemsNew__mainTitle
+          配送について
+        .itemsNew__innerContainer
+          .itemsNew__title
+            .itemsNew__subTitle
+              配送料の負担
+            .itemsNew__tag
+              必須
+          = f.select :fee_which, Item.fee_whiches.keys,{include_blank: "---",prompt: '選択してください'}, class: "itemsNew__selectBox"
+          .itemsNew__alert.displayNone
+            選択してください
+          = render partial: 'error-messages', locals: { item: @item, column: "fee_which"}
+
+        .itemsNew__innerContainer
+          .itemsNew__title
+            .itemsNew__subTitle
+              発送元の地域
+            .itemsNew__tag
+              必須
+          = f.select :from_where, Item.from_wheres.keys,{include_blank: "---",prompt: '選択してください'}, class: "itemsNew__selectBox"
+          .itemsNew__alert.displayNone
+            選択してください
+          = render partial: 'error-messages', locals: { item: @item, column: "from_where"}
+
+        .itemsNew__innerContainer
+          .itemsNew__title
+            .itemsNew__subTile
+              発送までの日数
+            .itemsNew__tag
+              必須
+          = f.select :delivery_date, Item.delivery_dates.keys,{include_blank: "---",prompt: '選択してください'}, class: "itemsNew__selectBox"
+          .itemsNew__alert.displayNone
+            選択してください
+          = render partial: 'error-messages', locals: { item: @item, column: "delivery_date"}
+
+      .itemsNew__container
+        .itemsNew__mainTitle
+          価格（¥300〜9,999,999）
+        .itemsNew__sellContainer
+          .itemsNew__title
+            .itemsNew__subTitle
+              販売価格
+            .itemsNew__tag
+              必須
+          .itemsNew__sellPriceBox
+            ¥
+            = f.number_field :price, placeholder: "0", class: "itemsNew__inputBox--sellPrice", min: "300", max: "9999999", style: "text-align: right;"
+        .itemsNew__alertInputBox
+          .itemsNew__alertInputBox2.displayNone
+            300以上9999999以下で入力してください
+        = render partial: 'error-messages', locals: { item: @item, column: "price"}
+
+        .itemsNew__sellPrice
+          .itemsNew__sellPrice--left
+            販売手数料（10%）
+          .itemsNew__sellPrice--right
+            ー
+
+        .itemsNew__priceProfit
+          .itemsNew__sellPrice--left
+            販売利益
+          .itemsNew__priceProfit--right
+            ー
+        .itemsNew__btnContainer
+          .itemsNew__modalOpen
+            -# buyer_idに初期状態である0（未売却）を入れる
+            = f.hidden_field :buyer_id, value: "0"
+            = f.submit "変更する", class:"itemsNew__sellBtn",data: { disable_with: "更新中..." }
+            %button{type: "submit", class: "itemsNew__sellBtn itemsNew__backBtn"}
+              もどる
+
+        .itemsNew__note
+          禁止されている
+          %span>
+          = link_to('行為', {}, class: 'itemsNew__noteLink')
+          %span>
+          および
+          %span>
+          = link_to('出品物', {}, class: 'itemsNew__noteLink')
+          %span>
+          を必ずご確認ください。
+          %span>
+          = link_to('偽ブランド品', {}, class: 'itemsNew__noteLink')
+          %span>
+          や
+          %span>
+          = link_to('盗品物', {}, class: 'itemsNew__noteLink')
+          %span>
+          などの販売は犯罪であり、法律により処罰される可能性があります。 また、出品をもちまして
+          %span>
+          = link_to('加盟店規約', {}, class: 'itemsNew__noteLink')
+          %span>
+          に同意したことになります。
+
+  .itemsNew__footer
+    .itemsNew__footerTop
+      %ul.itemsNew__footerUl
+        %li.itemsNew__footerList
+          = link_to('プライバシーポリシー', {}, class: 'itemsNew__footerList--link')
+        %li.itemsNew__footerList
+          = link_to('フリマ利用規約', {}, class: 'itemsNew__footerList--link')
+        %li.itemsNew__footerList
+          = link_to('特定商品に関する表記', {}, class: 'itemsNew__footerList--link')
+
+    .itemsNew__footerLogo
+      = image_tag 'logo-blue.png', alt: 'FURIMA', class: 'itemsNew__logo'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -38,22 +38,22 @@
                 %button#delete-comformation-btn 削除する
 
         -else
-          -if @item.buyer_id == nil
+          -if @item.buyer_id > 0
+            .mainBox__soldBtn
+              SOLD OUT
+          -else 
             = link_to confirm_item_path(@item) do
               .mainBox__buyBtn
                 購入画面に進む
-          -else 
-            .mainBox__soldBtn
-              SOLD OUT
 
       -else
-        -if @item.buyer_id == nil
-          -# = link_to confirm_item_path(@item) do
-          -#   -# .mainBox__buyBtn
-          -#   -#   購入画面に進む
-        -else 
+        -if @item.buyer_id > 0
           .mainBox__soldBtn
             SOLD OUT
+        -else 
+          = link_to confirm_item_path(@item) do
+            .mainBox__buyBtn
+              購入画面に進む
 
     %table.mainTable
       %tr

--- a/app/views/tops/index.html.haml
+++ b/app/views/tops/index.html.haml
@@ -108,14 +108,11 @@
     .productList__items
       -@lastItem.each do |item|
         .productList__items__item
-          -if item.buyer_id
+          -if item.buyer_id != nil
             .productList__items__item__sold
               SOLD
           = link_to "items/#{item.id}" do
             = image_tag item.images[0].url
-            -# = image_tag item.url
-            -# = image_tag "free_img1.jpg"
-            -# = item.thumbnail
             .productList__items__item__text
               %h8.name
                 = item.name

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,6 +2,8 @@ ja:
   activerecord:
     models:
       user: ユーザー
+      item: 商品
+      image: 画像
     attributes:
       user:
         nickname: ニックネーム
@@ -20,3 +22,19 @@ ja:
         city: 市
         address: 番地
         telephone: 電話番号
+
+      item:
+        category_id: カテゴリー
+        name: 出品名
+        explanation: 商品の説明
+        condition: 商品の状態
+        price: 金額
+        size: サイズ
+        fee_which: 配送料の負担
+        from_where: 発送元の地域
+        delivery_date: 発送までの日数
+        
+      image:
+        url: 画像
+
+


### PR DESCRIPTION
## waht
・すでに登録されている情報はeditページで表示されている
・必須項目が空の場合、editページにrenderされエラーメッセージが表示される

## why
・ユーザーが編集しやすいようにすでに登録済みの情報は表示させる
・空の内容が登録されないよう必須項目はバリデーションをかけ、エラーメッセージが出るように実装